### PR TITLE
Always return response in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ const users = api.request('users').get();
 
 // Custom POST request
 await api.request('users')
-    .onSuccess((response) => {
+    .onSuccess((data, response) => {
         // Handle success
     })
     .post({
@@ -295,7 +295,7 @@ let request = await api.request('users/files')
 - You can set response events directly on requests so they will only be called for that specific request. After executing the request, they will be automatically reset.
 ```javascript
 let request = await api.request('users')
-    .onSuccess((data) => {
+    .onSuccess((data, response) => {
         // Request successful.
     })
     .onUnauthorized((response) => {
@@ -304,7 +304,7 @@ let request = await api.request('users')
     .onForbidden((response) => {
         // Access not allowed.
     })
-    .onValidationError((validation) => {
+    .onValidationError((validation, response) => {
         // validation.message
         // validation.errors
     })

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,9 +24,9 @@ declare class Api {
     setHeader(key: string, value: string): void;
     removeHeader(key: string): void;
 
-    onSuccess(callback?: (data: any) => void): this;
+    onSuccess(callback?: (data: any, response: AxiosResponse) => void): this;
     onError(callback?: (response: AxiosResponse) => void): this;
-    onValidationError(callback?: (validation: any) => void): this;
+    onValidationError(callback?: (validation: any, response: AxiosResponse) => void): this;
     onUnauthorized(callback?: (response: AxiosResponse) => void): this;
     onForbidden(callback?: (response: AxiosResponse) => void): this;
     onFinished(callback?: (response: AxiosResponse) => void): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,9 +83,9 @@ declare class Request extends Mixins {
     delete(): Promise<this>;
     storeFiles(files?: object, data?: object, url?: string|null): Promise<this>;
     readonly bodyParameters: object;
-    onSuccess<T = any>(callback?: (result: T, data: any) => void): this;
+    onSuccess<T = any>(callback?: (result: T, data: any, response: Response) => void): this;
     onError(callback?: (response: Response) => void): this;
-    onValidationError(callback?: (validation: object) => void): this;
+    onValidationError(callback?: (validation: object, response: Response) => void): this;
     onUnauthorized(callback?: (response: Response) => void): this;
     onForbidden(callback?: (response: Response) => void): this;
     onFinished(callback?: (response: Response) => void): this;

--- a/src/response/responseEventsHandler.js
+++ b/src/response/responseEventsHandler.js
@@ -75,7 +75,8 @@ export default class ResponseEventsHandler {
     async _executeOnSuccessCallbacks (response) {
         await this._executeCallbacks(
             this._responseEventsList.flatMap((responseEvent) => responseEvent._onSuccessCallbacks),
-            ...[this._onSuccessData, response.data].filter((value) => !! value)
+            ...[this._onSuccessData, response.data].filter((value) => !! value),
+            response
         );
     }
 
@@ -103,7 +104,8 @@ export default class ResponseEventsHandler {
 
         await this._executeCallbacks(
             this._responseEventsList.flatMap((responseEvent) => responseEvent._onValidationErrorCallbacks),
-            validation
+            validation,
+            response
         );
     }
 


### PR DESCRIPTION
We now get a response as a parameter in the success and validationError callbacks.